### PR TITLE
chore: cleanup logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 *cache*
 get_all.R
 *.parquet
+get_all.log


### PR DESCRIPTION
Minor cleanup:
- Ignores `get_all.log`
- Removes tracked `get_all.log` file